### PR TITLE
njs-related changes

### DIFF
--- a/.github/workflows/njs-buildbot.yml
+++ b/.github/workflows/njs-buildbot.yml
@@ -3,6 +3,9 @@ name: ci
 on:
   workflow_call:
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   check-if-allowed:
     if: ${{ ( github.repository_owner == 'nginx' || github.repository_owner == 'nginxinc' ) }}

--- a/.github/workflows/njs-buildbot.yml
+++ b/.github/workflows/njs-buildbot.yml
@@ -32,6 +32,7 @@ jobs:
           exit 0
 
   test:
+    name: ${{ matrix.os }}, ${{ matrix.subarch != '' && matrix.subarch || matrix.arch }}
     runs-on: [ "${{ matrix.os }}-${{ matrix.arch }}" ]
     needs: check-if-allowed
     strategy:
@@ -264,6 +265,7 @@ jobs:
           TEST_NGINX_VERBOSE: 1
 
   asan:
+    name: ubuntu-22.04, amd64, asan, ${{ matrix.backend }}
     runs-on: [ ubuntu-22.04-amd64 ]
     needs: check-if-allowed
     strategy:
@@ -345,6 +347,7 @@ jobs:
           TEST_NGINX_VERBOSE: 1
 
   msan:
+    name: ubuntu-22.04, amd64, msan
     runs-on: [ ubuntu-22.04-amd64 ]
     needs: check-if-allowed
     env:
@@ -415,6 +418,7 @@ jobs:
           make clean
 
   print:
+    name: debian-12, amd64, print
     runs-on: [ debian-12-amd64 ]
     needs: check-if-allowed
 

--- a/.github/workflows/njs-buildbot.yml
+++ b/.github/workflows/njs-buildbot.yml
@@ -38,6 +38,7 @@ jobs:
       matrix:
         os: [ alpine-3.19, amazonlinux-2, amazonlinux-2023, debian-11, debian-12, freebsd-14, rhel-7, rhel-8, rhel-9, sles-12, ubuntu-20.04, ubuntu-22.04, ubuntu-23.10 ]
         arch: [ amd64, arm64 ]
+        subarch: [ '' ]
         exclude:
           - os: rhel-7 # AWS does not provide an RHEL 7 arm64 AMI
             arch: arm64
@@ -47,7 +48,8 @@ jobs:
             arch: arm64
         include:
           - os: debian-12
-            arch: x86
+            arch: amd64
+            subarch: x86
       fail-fast: false
 
     steps:
@@ -167,7 +169,7 @@ jobs:
                 export DEB_CFLAGS_MAINT_APPEND=$(echo $ENV_JSON | jq -r '."${{ matrix.os }}".DEB_CFLAGS_MAINT_APPEND')
                 export DEB_LDFLAGS_MAINT_APPEND=$(echo $ENV_JSON | jq -r '."${{ matrix.os }}".DEB_LDFLAGS_MAINT_APPEND')
                 CC_OPT=$(echo $ENV_JSON | jq -r '."${{ matrix.os }}".CC_OPT')
-                case "${{ matrix.arch }}" in
+                case "${{ matrix.subarch }}" in
                   x86)
                     CC_OPT_ADD="-m32"
                     LD_OPT_ADD="-m32"
@@ -185,7 +187,7 @@ jobs:
 
             NGINX_CONFIGURE_CMD=$(echo $ENV_JSON | jq -r '.NGINX_CONFIGURE_CMD')
             NGINX_CONFIGURE_CMD_APPEND=$(echo $ENV_JSON | jq -r '."${{ matrix.os }}".NGINX_CONFIGURE_CMD_APPEND // empty')
-            case "${{ matrix.arch }}" in
+            case "${{ matrix.subarch }}" in
               x86)
                 NGINX_CONFIGURE_CMD_APPEND="--with-perl=/usr/bin/perl5.36-i386-linux-gnu"
                 ;;


### PR DESCRIPTION
Dropped a special runner defition for debian12-x86 build - allows us to save some space in runner-matcher-config in self-hosted runners defs

And provided a bit more beautiful names

See the results at https://github.com/nginx/njs-sandbox/actions/runs/9787529791 (failed jobs due to https://github.com/actions/checkout/issues/1809)