### PR TITLE
nginx,njs: decreased verbosity of the initial test pass. 

### DIFF
--- a/.github/workflows/nginx-buildbot.yml
+++ b/.github/workflows/nginx-buildbot.yml
@@ -342,7 +342,7 @@ jobs:
       - name: Test package-max
         working-directory: nginx-tests
         run: |
-          prove -v -j$(nproc) --state=save ../t . || prove -v --state=failed
+          prove -j$(nproc) --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/objs/nginx"
           TEST_NGINX_VERBOSE: 1
@@ -368,7 +368,7 @@ jobs:
       - name: Test package-max debug
         working-directory: nginx-tests
         run: |
-          prove -v -j$(nproc) --state=save ../t . || prove -v --state=failed
+          prove -j$(nproc) --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/objs/nginx"
           TEST_NGINX_VERBOSE: 1
@@ -403,7 +403,7 @@ jobs:
       - name: Test dynamic
         working-directory: nginx-tests
         run: |
-          prove -v -j$(nproc) --state=save ../t . || prove -v --state=failed
+          prove -j$(nproc) --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/objs/nginx"
           TEST_NGINX_GLOBALS: "load_module ${{ github.workspace }}/objs/ngx_http_image_filter_module.so;load_module ${{ github.workspace }}/objs/ngx_http_perl_module.so;load_module ${{ github.workspace }}/objs/ngx_http_xslt_filter_module.so;"
@@ -441,7 +441,7 @@ jobs:
       - name: Test dynamic debug
         working-directory: nginx-tests
         run: |
-          prove -v -j$(nproc) --state=save ../t . || prove -v --state=failed
+          prove -j$(nproc) --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/objs/nginx"
           TEST_NGINX_GLOBALS: "load_module ${{ github.workspace }}/objs/ngx_http_image_filter_module.so;load_module /${{ github.workspace }}/objs/ngx_http_perl_module.so;load_module /${{ github.workspace }}/objs/ngx_http_xslt_filter_module.so;"
@@ -468,7 +468,7 @@ jobs:
       - name: Test aio
         working-directory: nginx-tests
         run: |
-          prove -v -j$(nproc) --state=save ../t . || prove -v --state=failed
+          prove -j$(nproc) --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/objs/nginx"
           TEST_NGINX_VERBOSE: 1
@@ -479,7 +479,7 @@ jobs:
       - name: Test aio-write
         working-directory: nginx-tests
         run: |
-          prove -v -j$(nproc) --state=save ../t . || prove -v --state=failed
+          prove -j$(nproc) --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/objs/nginx"
           TEST_NGINX_VERBOSE: 1
@@ -507,7 +507,7 @@ jobs:
       - name: Test aio debug
         working-directory: nginx-tests
         run: |
-          prove -v -j$(nproc) --state=save ../t . || prove -v --state=failed
+          prove -j$(nproc) --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/objs/nginx"
           TEST_NGINX_VERBOSE: 1
@@ -518,7 +518,7 @@ jobs:
       - name: Test aio-write debug
         working-directory: nginx-tests
         run: |
-          prove -v -j$(nproc) --state=save ../t . || prove -v --state=failed
+          prove -j$(nproc) --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/objs/nginx"
           TEST_NGINX_VERBOSE: 1
@@ -551,7 +551,7 @@ jobs:
       - name: Test ndb
         if: ${{ matrix.subarch == '' }}
         run: |
-          prove -v -j$(nproc) --state=save ./ndb/t || prove -v --state=failed
+          prove -j$(nproc) --state=save ./ndb/t || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/objs/nginx"
           TEST_NGINX_VERBOSE: 1
@@ -726,7 +726,7 @@ jobs:
         working-directory: nginx-tests
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) --state=save ../t . || prove -v --state=failed
+          prove -j$(nproc) --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/objs/nginx"
           TEST_NGINX_VERBOSE: 1
@@ -893,7 +893,7 @@ jobs:
         shell: cmd
         working-directory: nginx-tests
         run: |
-          prove -v --state=save ../t . || prove -v --state=failed
+          prove --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}\\objs\\nginx.exe"
           TEST_NGINX_VERBOSE: 1
@@ -934,7 +934,7 @@ jobs:
         shell: cmd
         working-directory: nginx-tests
         run: |
-          prove -v --state=save ../t . || prove -v --state=failed
+          prove --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}\\objs\\nginx.exe"
           TEST_NGINX_VERBOSE: 1
@@ -963,7 +963,7 @@ jobs:
         shell: cmd
         working-directory: nginx-tests
         run: |
-          prove -v --state=save ../t . || prove -v --state=failed
+          prove --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}\\objs\\nginx.exe"
           TEST_NGINX_VERBOSE: 1

--- a/.github/workflows/nginx-check-pr.yml
+++ b/.github/workflows/nginx-check-pr.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Test
         working-directory: nginx-tests
         run: |
-          prove -v -j$(nproc) --state=save ../t . || prove -v --state=failed
+          prove -j$(nproc) --state=save ../t . || prove -v --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/objs/nginx"
           TEST_NGINX_VERBOSE: 1

--- a/.github/workflows/njs-buildbot.yml
+++ b/.github/workflows/njs-buildbot.yml
@@ -277,7 +277,7 @@ jobs:
       - name: Test njs modules
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+          prove -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
           TEST_NGINX_GLOBALS: "load_module ${{ github.workspace }}/nginx-source/objs/ngx_http_js_module.so; load_module ${{ github.workspace }}/nginx-source/objs/ngx_stream_js_module.so;"
@@ -296,7 +296,7 @@ jobs:
       - name: Test njs modules, static modules
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+          prove -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
           TEST_NGINX_VERBOSE: 1
@@ -304,7 +304,7 @@ jobs:
       - name: Test njs modules (js_engine qjs), static modules
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+          prove -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
           TEST_NGINX_GLOBALS_HTTP: "js_engine qjs;"
@@ -325,7 +325,7 @@ jobs:
       - name: Test njs modules, dynamic modules
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+          prove -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
           TEST_NGINX_GLOBALS: "load_module ${{ github.workspace }}/nginx-source/objs/ngx_http_js_module.so; load_module ${{ github.workspace }}/nginx-source/objs/ngx_stream_js_module.so;"
@@ -334,7 +334,7 @@ jobs:
       - name: Test njs modules (js_engine qjs), dynamic modules
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+          prove -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
           TEST_NGINX_GLOBALS: "load_module ${{ github.workspace }}/nginx-source/objs/ngx_stream_js_module.so; load_module ${{ github.workspace }}/nginx-source/objs/ngx_http_js_module.so;"
@@ -356,7 +356,7 @@ jobs:
       - name: Test njs modules, quickjs-ng, dynamic modules
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+          prove -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
           TEST_NGINX_GLOBALS: "load_module ${{ github.workspace }}/nginx-source/objs/ngx_http_js_module.so; load_module ${{ github.workspace }}/nginx-source/objs/ngx_stream_js_module.so;"
@@ -365,7 +365,7 @@ jobs:
       - name: Test njs modules (js_engine qjs), quickjs-ng, dynamic modules
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+          prove -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
           TEST_NGINX_GLOBALS: "load_module ${{ github.workspace }}/nginx-source/objs/ngx_stream_js_module.so; load_module ${{ github.workspace }}/nginx-source/objs/ngx_http_js_module.so;"
@@ -481,7 +481,7 @@ jobs:
       - name: Test njs modules
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+          prove -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
         env:
           ASAN_OPTIONS: "detect_odr_violation=0:report_globals=0"
           LSAN_OPTIONS: "suppressions=${{ github.workspace }}/lsan_suppressions.txt"
@@ -515,7 +515,7 @@ jobs:
         if: matrix.backend == 'quickjs' || matrix.backend == 'quickjs-ng'
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+          prove -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
           TEST_NGINX_VERBOSE: 1
@@ -526,7 +526,7 @@ jobs:
         if: matrix.backend == 'quickjs' || matrix.backend == 'quickjs-ng'
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+          prove -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
           TEST_NGINX_GLOBALS_HTTP: "js_engine qjs;"
@@ -563,7 +563,7 @@ jobs:
         if: matrix.backend == 'quickjs' || matrix.backend == 'quickjs-ng'
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+          prove -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
           TEST_NGINX_GLOBALS: "load_module ${{ github.workspace }}/nginx-source/objs/ngx_http_js_module.so; load_module ${{ github.workspace }}/nginx-source/objs/ngx_stream_js_module.so;"
@@ -575,7 +575,7 @@ jobs:
         if: matrix.backend == 'quickjs' || matrix.backend == 'quickjs-ng'
         run: |
           ulimit -c unlimited
-          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+          prove -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
         env:
           TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
           TEST_NGINX_GLOBALS: "load_module ${{ github.workspace }}/nginx-source/objs/ngx_stream_js_module.so; load_module ${{ github.workspace }}/nginx-source/objs/ngx_http_js_module.so;"


### PR DESCRIPTION
Recently I noticed that the test logs in UI are truncated, and archive downloads fail at ~70M. "View raw logs" is truncated in browser, but can be fetched with curl (92M), making it the only way to see the test results and any failures in the initial pass.
The situation is not optimal, so it makes sense to run the first pass with a regular log level and only apply `-v` when retrying the failed tests.

The downside is that we may miss `-v` and  `TEST_NGINX_VERBOSE` output for intermittent failures or problems caused by parallelization, that aren't reproducible on the `prove -v --state=failed` pass. But since we cannot notice such issues from the truncated part of the log anyways, this doesn't seem critical.

njs with ~6000 lines of test logs does not exhibit the same problem; njs-buildbot has been changed just to be consistent.