### PR TITLE
nginx-buildbot: caught up with BoringSSL build changes.

### DIFF
--- a/.github/workflows/nginx-buildbot.yml
+++ b/.github/workflows/nginx-buildbot.yml
@@ -652,7 +652,7 @@ jobs:
               git clone https://boringssl.googlesource.com/boringssl ssl
               mkdir ssl/build
               cd ssl/build
-              cmake ..
+              cmake .. -DBUILD_TESTING=off
               make -j$(nproc)
             ;;
             lssl)

--- a/.github/workflows/nginx-buildbot.yml
+++ b/.github/workflows/nginx-buildbot.yml
@@ -705,7 +705,7 @@ jobs:
           mkdir -p t/
           case "${{ matrix.ssl }}" in
             bssl)
-              LD_OPT="-L ssl/build/ssl -L ssl/build/crypto -lstdc++"
+              LD_OPT="-L ssl/build -lstdc++"
               ;;
             lssl)
               LD_OPT="-L ssl/ssl/.libs -L ssl/crypto/.libs"


### PR DESCRIPTION
See for details:
https://boringssl.googlesource.com/boringssl/+/5e3ba4c15
