### PR TITLE
Added new workers, removed some older ones

### DIFF
--- a/.github/workflows/nginx-buildbot.yml
+++ b/.github/workflows/nginx-buildbot.yml
@@ -53,6 +53,8 @@ jobs:
             arch: arm64
           - os: alpine-3.21
             arch: arm64
+          - os: amazonlinux-2
+            arch: arm64
           - os: freebsd-14
             arch: arm64
           - os: rhel-10

--- a/.github/workflows/nginx-buildbot.yml
+++ b/.github/workflows/nginx-buildbot.yml
@@ -44,7 +44,7 @@ jobs:
     needs: check-if-allowed
     strategy:
       matrix:
-        os: [ alpine-3.19, alpine-3.20, alpine-3.21, alpine-3.22, amazonlinux-2, amazonlinux-2023, debian-11, debian-12, freebsd-14, rhel-8, rhel-9, rhel-10, sles-15, ubuntu-22.04, ubuntu-24.04, ubuntu-25.04 ]
+        os: [ alpine-3.19, alpine-3.20, alpine-3.21, alpine-3.22, amazonlinux-2, amazonlinux-2023, debian-11, debian-12, debian-13, freebsd-14, rhel-8, rhel-9, rhel-10, sles-15, ubuntu-22.04, ubuntu-24.04, ubuntu-25.04 ]
         arch: [ amd64, arm64 ]
         subarch: [ '' ]
         sanitizer: [ '' ]
@@ -58,6 +58,8 @@ jobs:
           - os: amazonlinux-2
             arch: arm64
           - os: freebsd-14
+            arch: arm64
+          - os: debian-13
             arch: arm64
           - os: rhel-10
             arch: arm64
@@ -116,6 +118,10 @@ jobs:
               "LD_OPT": "$(DEB_BUILD_MAINT_OPTIONS=hardening=+all DEB_CFLAGS_MAINT_APPEND=-fPIC DEB_LDFLAGS_MAINT_APPEND=-Wl,--as-needed dpkg-buildflags --get LDFLAGS)"
             },
             "debian-12": {
+              "CC_OPT": "$(DEB_BUILD_MAINT_OPTIONS=hardening=+all DEB_CFLAGS_MAINT_APPEND=-fPIC DEB_LDFLAGS_MAINT_APPEND=-Wl,--as-needed dpkg-buildflags --get CFLAGS)",
+              "LD_OPT": "$(DEB_BUILD_MAINT_OPTIONS=hardening=+all DEB_CFLAGS_MAINT_APPEND=-fPIC DEB_LDFLAGS_MAINT_APPEND=-Wl,--as-needed dpkg-buildflags --get LDFLAGS)"
+            },
+            "debian-13": {
               "CC_OPT": "$(DEB_BUILD_MAINT_OPTIONS=hardening=+all DEB_CFLAGS_MAINT_APPEND=-fPIC DEB_LDFLAGS_MAINT_APPEND=-Wl,--as-needed dpkg-buildflags --get CFLAGS)",
               "LD_OPT": "$(DEB_BUILD_MAINT_OPTIONS=hardening=+all DEB_CFLAGS_MAINT_APPEND=-fPIC DEB_LDFLAGS_MAINT_APPEND=-Wl,--as-needed dpkg-buildflags --get LDFLAGS)"
             },

--- a/.github/workflows/nginx-buildbot.yml
+++ b/.github/workflows/nginx-buildbot.yml
@@ -44,7 +44,7 @@ jobs:
     needs: check-if-allowed
     strategy:
       matrix:
-        os: [ alpine-3.19, alpine-3.20, alpine-3.21, amazonlinux-2, amazonlinux-2023, debian-11, debian-12, freebsd-14, rhel-8, rhel-9, rhel-10, sles-15, ubuntu-22.04, ubuntu-24.04, ubuntu-25.04 ]
+        os: [ alpine-3.19, alpine-3.20, alpine-3.21, alpine-3.22, amazonlinux-2, amazonlinux-2023, debian-11, debian-12, freebsd-14, rhel-8, rhel-9, rhel-10, sles-15, ubuntu-22.04, ubuntu-24.04, ubuntu-25.04 ]
         arch: [ amd64, arm64 ]
         subarch: [ '' ]
         sanitizer: [ '' ]
@@ -52,6 +52,8 @@ jobs:
           - os: alpine-3.20
             arch: arm64
           - os: alpine-3.21
+            arch: arm64
+          - os: alpine-3.22
             arch: arm64
           - os: amazonlinux-2
             arch: arm64
@@ -94,6 +96,10 @@ jobs:
               "LD_OPT": "$(. /usr/share/abuild/default.conf; echo $LDFLAGS)"
             },
             "alpine-3.21": {
+              "CC_OPT": "$(. /usr/share/abuild/default.conf; echo $CFLAGS)",
+              "LD_OPT": "$(. /usr/share/abuild/default.conf; echo $LDFLAGS)"
+            },
+            "alpine-3.22": {
               "CC_OPT": "$(. /usr/share/abuild/default.conf; echo $CFLAGS)",
               "LD_OPT": "$(. /usr/share/abuild/default.conf; echo $LDFLAGS)"
             },

--- a/.github/workflows/nginx-buildbot.yml
+++ b/.github/workflows/nginx-buildbot.yml
@@ -49,6 +49,8 @@ jobs:
         subarch: [ '' ]
         sanitizer: [ '' ]
         exclude:
+          - os: alpine-3.20
+            arch: arm64
           - os: alpine-3.21
             arch: arm64
           - os: freebsd-14

--- a/.github/workflows/njs-buildbot.yml
+++ b/.github/workflows/njs-buildbot.yml
@@ -44,6 +44,8 @@ jobs:
         arch: [ amd64, arm64 ]
         subarch: [ '' ]
         exclude:
+          - os: alpine-3.20
+            arch: arm64
           - os: alpine-3.21
             arch: arm64
           - os: freebsd-14

--- a/.github/workflows/njs-buildbot.yml
+++ b/.github/workflows/njs-buildbot.yml
@@ -40,7 +40,7 @@ jobs:
     needs: check-if-allowed
     strategy:
       matrix:
-        os: [ alpine-3.19, alpine-3.20, alpine-3.21, alpine-3.22, amazonlinux-2, amazonlinux-2023, debian-11, debian-12, freebsd-14, rhel-8, rhel-9, rhel-10, sles-15, ubuntu-22.04, ubuntu-24.04, ubuntu-25.04 ]
+        os: [ alpine-3.19, alpine-3.20, alpine-3.21, alpine-3.22, amazonlinux-2, amazonlinux-2023, debian-11, debian-12, debian-13, freebsd-14, rhel-8, rhel-9, rhel-10, sles-15, ubuntu-22.04, ubuntu-24.04, ubuntu-25.04 ]
         arch: [ amd64, arm64 ]
         subarch: [ '' ]
         exclude:
@@ -53,6 +53,8 @@ jobs:
           - os: amazonlinux-2
             arch: arm64
           - os: freebsd-14
+            arch: arm64
+          - os: debian-13
             arch: arm64
           - os: rhel-10
             arch: arm64
@@ -124,6 +126,15 @@ jobs:
               "type": "deb"
             },
             "debian-12": {
+              "NGINX_CONFIGURE_CMD_APPEND": "--with-http_geoip_module --with-stream_geoip_module",
+              "DEB_BUILD_MAINT_OPTIONS": "hardening=+all",
+              "DEB_CFLAGS_MAINT_APPEND": "-Wp,-D_FORTIFY_SOURCE=2 -fPIC",
+              "DEB_LDFLAGS_MAINT_APPEND": "-Wl,--as-needed",
+              "CC_OPT": "dpkg-buildflags --get CFLAGS",
+              "LD_OPT": "dpkg-buildflags --get LDFLAGS",
+              "type": "deb"
+            },
+            "debian-13": {
               "NGINX_CONFIGURE_CMD_APPEND": "--with-http_geoip_module --with-stream_geoip_module",
               "DEB_BUILD_MAINT_OPTIONS": "hardening=+all",
               "DEB_CFLAGS_MAINT_APPEND": "-Wp,-D_FORTIFY_SOURCE=2 -fPIC",

--- a/.github/workflows/njs-buildbot.yml
+++ b/.github/workflows/njs-buildbot.yml
@@ -48,6 +48,8 @@ jobs:
             arch: arm64
           - os: alpine-3.21
             arch: arm64
+          - os: amazonlinux-2
+            arch: arm64
           - os: freebsd-14
             arch: arm64
           - os: rhel-10

--- a/.github/workflows/njs-buildbot.yml
+++ b/.github/workflows/njs-buildbot.yml
@@ -40,13 +40,15 @@ jobs:
     needs: check-if-allowed
     strategy:
       matrix:
-        os: [ alpine-3.19, alpine-3.20, alpine-3.21, amazonlinux-2, amazonlinux-2023, debian-11, debian-12, freebsd-14, rhel-8, rhel-9, rhel-10, sles-15, ubuntu-22.04, ubuntu-24.04, ubuntu-25.04 ]
+        os: [ alpine-3.19, alpine-3.20, alpine-3.21, alpine-3.22, amazonlinux-2, amazonlinux-2023, debian-11, debian-12, freebsd-14, rhel-8, rhel-9, rhel-10, sles-15, ubuntu-22.04, ubuntu-24.04, ubuntu-25.04 ]
         arch: [ amd64, arm64 ]
         subarch: [ '' ]
         exclude:
           - os: alpine-3.20
             arch: arm64
           - os: alpine-3.21
+            arch: arm64
+          - os: alpine-3.22
             arch: arm64
           - os: amazonlinux-2
             arch: arm64
@@ -90,6 +92,12 @@ jobs:
               "type": "apk"
             },
             "alpine-3.21": {
+              "NGINX_CONFIGURE_CMD_APPEND": "--with-http_geoip_module --with-stream_geoip_module",
+              "CC_OPT": "$(. /usr/share/abuild/default.conf; echo $CFLAGS)",
+              "LD_OPT": "$(. /usr/share/abuild/default.conf; echo $LDFLAGS)",
+              "type": "apk"
+            },
+            "alpine-3.22": {
               "NGINX_CONFIGURE_CMD_APPEND": "--with-http_geoip_module --with-stream_geoip_module",
               "CC_OPT": "$(. /usr/share/abuild/default.conf; echo $CFLAGS)",
               "LD_OPT": "$(. /usr/share/abuild/default.conf; echo $LDFLAGS)",


### PR DESCRIPTION
Adds Alpine 3.22 and Debian 13 to the list of jobs we check for both NGINX and NJS.

This also removes less-useful arm64 checks for Amazon Linux 2 and Alpine 3.20.

We have to remove some less useful workers because of the limit of architectures/OSes we can support with self-hosted runners.

Note that we need to merge this at the same time as the same changes be propagated to the self-hosted runners images repo.  So looking for a review & ack, and will merge it myself afterwards.